### PR TITLE
fix(setup): use local variable for Install-Module splatting

### DIFF
--- a/Scripts/Initialize-SyncReceipts.ps1
+++ b/Scripts/Initialize-SyncReceipts.ps1
@@ -412,7 +412,8 @@ foreach ($module in @(
     } else {
         try {
             Write-Host "  Installing $($module.Name)..." -ForegroundColor Cyan
-            Install-Module $module.Name @($module.InstallArgs) -Scope CurrentUser -Force -ErrorAction Stop
+            $iArgs = $module.InstallArgs
+            Install-Module $module.Name @iArgs -Scope CurrentUser -Force -ErrorAction Stop
             Write-OK "Installed $($module.Name)"
         } catch {
             Write-Fail "Could not install $($module.Name) -- $_"


### PR DESCRIPTION
## Summary

`@($module.InstallArgs)` is an array subexpression, not splatting. For PSScriptAnalyzer whose `InstallArgs` is `@()`, PowerShell was passing an empty `System.Object[]` as a positional argument, causing setup to fail with:
> A positional parameter cannot be found that accepts argument 'System.Object[]'.

Assigning to `$iArgs` first ensures `@iArgs` is interpreted as the splat operator.

## Test plan
- [ ] Run `Scripts/Initialize-SyncReceipts.ps1` on a machine where PSScriptAnalyzer is not installed; confirm it installs without error
- [ ] CI (Pester) passes

Closes #65