### PR TITLE
fix(write-month): skip Amount NumberFormat when sheet has 0 receipts

### DIFF
--- a/Scripts/Sync-Receipts.ps1
+++ b/Scripts/Sync-Receipts.ps1
@@ -1273,10 +1273,13 @@ function Write-MonthSheet {
     }
 
     if ($table) {
-        try {
-            $table.ListColumns.Item($COL_AMOUNT).DataBodyRange.NumberFormat = '_($* #,##0.00_);[Red]_($* (#,##0.00);_($* "-"??_);_(@_)'
-        } catch {
-            Write-SyncLog "Amount format: could not set -- $_" -Tag WARN
+        $amountBodyRange = $table.ListColumns.Item($COL_AMOUNT).DataBodyRange
+        if ($amountBodyRange) {
+            try {
+                $amountBodyRange.NumberFormat = '_($* #,##0.00_);[Red]_($* (#,##0.00);_($* "-"??_);_(@_)'
+            } catch {
+                Write-SyncLog "Amount format: could not set -- $_" -Tag WARN
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

`DataBodyRange` is `$null` when the table has no data rows (header only). Setting `.NumberFormat` on a null reference threw a WARN on every sync of an empty month folder:
> The property 'NumberFormat' cannot be found on this object.

Guards with a null check on `DataBodyRange` before applying the format.

## Test plan
- [ ] Run sync against a month folder with zero receipt files; confirm no WARN in the log for NumberFormat
- [ ] CI (Pester) passes

Closes #66