### PR TITLE
fix(write-month): correct inactive account flag string to match docs

### DIFF
--- a/Scripts/Sync-Receipts.ps1
+++ b/Scripts/Sync-Receipts.ps1
@@ -1228,7 +1228,7 @@ function Write-MonthSheet {
             if (-not $match) {
                 $flag = "Account not in Accounts.xlsx"
             } elseif ($match.Status -eq "Inactive") {
-                $flag = "Inactive account"
+                $flag = "Account inactive"
             }
         }
         if ($flag -ne "") {


### PR DESCRIPTION
## Summary

Code wrote `"Inactive account"` but README and CHANGELOG document `"Account inactive"`. Users searching their workbook for the documented value found nothing.

Changes the string literal to match the documented behaviour.

## Test plan
- [ ] Run sync with a receipt whose account has `Status = Inactive` in `Config/Accounts.xlsx`; confirm the Flag cell reads `"Account inactive"`
- [ ] CI (Pester) passes

Closes #80