### PR TITLE
fix(ci): update actions/checkout from v6 to v4

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Install Pester
         shell: pwsh


### PR DESCRIPTION
## Summary
- `actions/checkout@v6` does not exist as a published release
- Updated both `tests.yml` and `commit-lint.yml` to `actions/checkout@v4` (current stable)

## Test plan
- [ ] CI passes on this PR

Closes #91