### PR TITLE
fix(config): fix Test:Unit only task to run existing test files

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -40,7 +40,7 @@
             "args": [
                 "-NoProfile",
                 "-Command",
-                "Import-Module Pester -MinimumVersion 5.0 -Force; Invoke-Pester ./Tests/Sync-Receipts.Tests.ps1 -Output Detailed"
+                "Import-Module Pester -MinimumVersion 5.0 -Force; Invoke-Pester (Get-ChildItem ./Tests -Filter '*.Tests.ps1' | Where-Object { $_.Name -ne 'Lint.Tests.ps1' }) -Output Detailed"
             ],
             "group": "test",
             "presentation": {


### PR DESCRIPTION
## Summary
- The "Test: Unit only" VS Code task referenced `./Tests/Sync-Receipts.Tests.ps1`, which does not exist — tests are organised one file per function
- Updated to run all `*.Tests.ps1` files in `Tests/` except `Lint.Tests.ps1`, matching the intended "unit tests without lint" scope

## Test plan
- [ ] Run the "Test: Unit only" VS Code task and confirm it runs all unit test files
- [ ] Confirm `Lint.Tests.ps1` is excluded from the run

Closes #99