### PR TITLE
test(tests): TestDrive isolation, edge cases, and lint guard

### DIFF
--- a/Tests/ConvertFrom-ReceiptFileName.Tests.ps1
+++ b/Tests/ConvertFrom-ReceiptFileName.Tests.ps1
@@ -127,12 +127,12 @@ Describe 'ConvertFrom-ReceiptFileName' {
     Context 'invalid filenames' {
 
         # Structural failures
-        It 'returns ParseOK=false for a non-receipt filename' {
+        It 'returns OK=false for a non-receipt filename' {
             $r = ConvertFrom-ReceiptFileName -Stem 'not a receipt'
             $r.OK | Should -Be $false
         }
 
-        It 'returns ParseOK=false and ParseError for a non-receipt filename' {
+        It 'returns OK=false and ParseError for a non-receipt filename' {
             $r = ConvertFrom-ReceiptFileName -Stem 'garbage'
             $r.OK         | Should -Be $false
             $r.ParseError | Should -Be 'Could not parse filename'
@@ -144,27 +144,28 @@ Describe 'ConvertFrom-ReceiptFileName' {
             $r.Amount  | Should -Be ''
             $r.Method  | Should -Be ''
             $r.Account | Should -Be ''
+            $r.Date    | Should -BeNullOrEmpty
         }
 
-        It 'returns ParseOK=false when amount has no decimal' {
+        It 'returns OK=false when amount has no decimal' {
             $r = ConvertFrom-ReceiptFileName -Stem '260301 Amazon -$10 Card 1234'
             $r.OK | Should -Be $false
         }
 
         # Date validation
-        It 'returns ParseOK=false and ParseError for an out-of-range month' {
+        It 'returns OK=false and ParseError for an out-of-range month' {
             $r = ConvertFrom-ReceiptFileName -Stem '261316 Amazon -$10.00 Card 1234'
             $r.OK         | Should -Be $false
             $r.ParseError | Should -Be 'Month out of range'
         }
 
-        It 'returns ParseOK=false and ParseError for an out-of-range day' {
+        It 'returns OK=false and ParseError for an out-of-range day' {
             $r = ConvertFrom-ReceiptFileName -Stem '260332 Amazon -$10.00 Card 1234'
             $r.OK         | Should -Be $false
             $r.ParseError | Should -Be 'Day out of range'
         }
 
-        It 'returns ParseOK=false and ParseError for an invalid date (e.g. Feb 31)' {
+        It 'returns OK=false and ParseError for an invalid date (e.g. Feb 31)' {
             $r = ConvertFrom-ReceiptFileName -Stem '260231 Amazon -$10.00 Card 1234'
             $r.OK         | Should -Be $false
             $r.ParseError | Should -Be 'Invalid date'
@@ -180,32 +181,38 @@ Describe 'ConvertFrom-ReceiptFileName' {
         # Missing account
         It 'rejects Card method with no account' {
             $r = ConvertFrom-ReceiptFileName -Stem '260301 Amazon -$10.00 Card'
-            $r.OK | Should -Be $false
+            $r.OK         | Should -Be $false
+            $r.ParseError | Should -Be 'Could not parse filename'
         }
 
         It 'rejects Checking method with no account' {
             $r = ConvertFrom-ReceiptFileName -Stem '260301 Bank -$100.00 Checking'
-            $r.OK | Should -Be $false
+            $r.OK         | Should -Be $false
+            $r.ParseError | Should -Be 'Could not parse filename'
         }
 
         It 'rejects Savings method with no account' {
             $r = ConvertFrom-ReceiptFileName -Stem '260301 ATM -$200.00 Savings'
-            $r.OK | Should -Be $false
+            $r.OK         | Should -Be $false
+            $r.ParseError | Should -Be 'Could not parse filename'
         }
 
         It 'rejects Check method with no account' {
             $r = ConvertFrom-ReceiptFileName -Stem '260301 Landlord -$1200.00 Check'
-            $r.OK | Should -Be $false
+            $r.OK         | Should -Be $false
+            $r.ParseError | Should -Be 'Could not parse filename'
         }
 
         It 'rejects Wire method with no account' {
             $r = ConvertFrom-ReceiptFileName -Stem '260301 Vendor -$500.00 Wire'
-            $r.OK | Should -Be $false
+            $r.OK         | Should -Be $false
+            $r.ParseError | Should -Be 'Could not parse filename'
         }
 
         It 'rejects Transfer method with no account' {
             $r = ConvertFrom-ReceiptFileName -Stem '260301 Friend -$50.00 Transfer'
-            $r.OK | Should -Be $false
+            $r.OK         | Should -Be $false
+            $r.ParseError | Should -Be 'Could not parse filename'
         }
     }
 
@@ -257,13 +264,13 @@ Describe 'ConvertFrom-ReceiptFileName' {
             $r.Method | Should -Be 'Cash'
         }
 
-        It 'returns ParseOK=false and ParseError for out-of-range month in yyyyMMdd' {
+        It 'returns OK=false and ParseError for out-of-range month in yyyyMMdd' {
             $r = ConvertFrom-ReceiptFileName -Stem '20261316 Amazon -$10.00 Card 1234' -DateFormat 'yyyyMMdd'
             $r.OK         | Should -Be $false
             $r.ParseError | Should -Be 'Month out of range'
         }
 
-        It 'returns ParseOK=false and ParseError for out-of-range day in yy-MM-dd' {
+        It 'returns OK=false and ParseError for out-of-range day in yy-MM-dd' {
             $r = ConvertFrom-ReceiptFileName -Stem '26-03-32 Amazon -$10.00 Card 1234' -DateFormat 'yy-MM-dd'
             $r.OK         | Should -Be $false
             $r.ParseError | Should -Be 'Day out of range'

--- a/Tests/Get-Methods.Tests.ps1
+++ b/Tests/Get-Methods.Tests.ps1
@@ -20,8 +20,8 @@ Describe 'Get-Methods' {
     Context 'reading from Methods.json' {
 
         It 'returns the token list from a valid JSON file' {
-            $dir = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.Guid]::NewGuid())
-            [System.IO.Directory]::CreateDirectory($dir) | Out-Null
+            $dir = Join-Path $TestDrive ([System.Guid]::NewGuid())
+            New-Item -ItemType Directory -Path $dir | Out-Null
             '["Card","Checking","Wire"]' | Set-Content (Join-Path $dir 'Methods.json')
             $result = Get-Methods -ConfigRoot $dir
             $result | Should -Contain 'Card'
@@ -31,24 +31,34 @@ Describe 'Get-Methods' {
         }
 
         It 'returns defaults when Methods.json is absent' {
-            $dir = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.Guid]::NewGuid())
-            [System.IO.Directory]::CreateDirectory($dir) | Out-Null
+            $dir = Join-Path $TestDrive ([System.Guid]::NewGuid())
+            New-Item -ItemType Directory -Path $dir | Out-Null
             $result = Get-Methods -ConfigRoot $dir
             $result | Should -Contain 'Card'
             $result | Should -Contain 'Checking'
+            $result.Count | Should -Be 6
         }
 
         It 'returns defaults when Methods.json is malformed' {
-            $dir = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.Guid]::NewGuid())
-            [System.IO.Directory]::CreateDirectory($dir) | Out-Null
+            $dir = Join-Path $TestDrive ([System.Guid]::NewGuid())
+            New-Item -ItemType Directory -Path $dir | Out-Null
             'not valid json' | Set-Content (Join-Path $dir 'Methods.json')
             $result = Get-Methods -ConfigRoot $dir
             $result | Should -Contain 'Card'
         }
 
+        It 'returns defaults when Methods.json contains an empty array' {
+            $dir = Join-Path $TestDrive ([System.Guid]::NewGuid())
+            New-Item -ItemType Directory -Path $dir | Out-Null
+            '[]' | Set-Content (Join-Path $dir 'Methods.json')
+            $result = Get-Methods -ConfigRoot $dir
+            $result | Should -Contain 'Card'
+            $result.Count | Should -Be 6
+        }
+
         It 'skips tokens containing spaces or special characters' {
-            $dir = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.Guid]::NewGuid())
-            [System.IO.Directory]::CreateDirectory($dir) | Out-Null
+            $dir = Join-Path $TestDrive ([System.Guid]::NewGuid())
+            New-Item -ItemType Directory -Path $dir | Out-Null
             '["Card","Bad Token","Wire"]' | Set-Content (Join-Path $dir 'Methods.json')
             $result = Get-Methods -ConfigRoot $dir
             $result | Should -Contain 'Card'
@@ -57,8 +67,8 @@ Describe 'Get-Methods' {
         }
 
         It 'returns defaults when all tokens are invalid' {
-            $dir = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.Guid]::NewGuid())
-            [System.IO.Directory]::CreateDirectory($dir) | Out-Null
+            $dir = Join-Path $TestDrive ([System.Guid]::NewGuid())
+            New-Item -ItemType Directory -Path $dir | Out-Null
             '["bad token","another bad"]' | Set-Content (Join-Path $dir 'Methods.json')
             $result = Get-Methods -ConfigRoot $dir
             $result | Should -Contain 'Card'

--- a/Tests/Lint.Tests.ps1
+++ b/Tests/Lint.Tests.ps1
@@ -7,6 +7,10 @@ BeforeAll {
     $script:scriptPath    = Join-Path (Split-Path $PSScriptRoot -Parent) 'Scripts\Sync-Receipts.ps1'
     $script:settingsPath  = Join-Path (Join-Path (Split-Path $PSScriptRoot -Parent) '.config') 'PSScriptAnalyzerSettings.psd1'
 
+    if (-not (Test-Path $script:settingsPath)) {
+        throw "PSScriptAnalyzerSettings.psd1 not found at '$script:settingsPath' -- lint results would be unreliable"
+    }
+
     $script:results = Invoke-ScriptAnalyzer -Path $script:scriptPath -Settings $script:settingsPath
 }
 

--- a/Tests/Set-SubcategoryValidationXml.Tests.ps1
+++ b/Tests/Set-SubcategoryValidationXml.Tests.ps1
@@ -295,5 +295,40 @@ Describe 'Set-SubcategoryValidationXml' {
             $out = Get-XlsxEntry -Path $p -Entry 'xl/worksheets/sheet1.xml'
             $out.IndexOf('<dataValidations') | Should -BeLessThan ($out.IndexOf('<tableParts'))
         }
+
+        It 'aborts without overwriting the workbook when the reconstructed zip is under 1 KB' {
+            # Build a two-entry zip: only xl/workbook.xml and xl/_rels/workbook.xml.rels.
+            # With DataEndRow=1 no sheet is patched; the reconstructed temp file contains
+            # only these two tiny entries and stays well under 1024 bytes, triggering the
+            # size-guard early-return path.
+            $p = Join-Path $TestDrive 'tiny.xlsx'
+            Add-Type -AssemblyName System.IO.Compression
+            Add-Type -AssemblyName System.IO.Compression.FileSystem
+            $tinyFiles = [ordered]@{
+                'xl/workbook.xml'            = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+                    '<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"' +
+                    ' xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">' +
+                    '<sheets><sheet name="2603" sheetId="1" r:id="rId1"/></sheets></workbook>'
+                'xl/_rels/workbook.xml.rels' = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+                    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+                    '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>' +
+                    '</Relationships>'
+            }
+            $zip = [System.IO.Compression.ZipFile]::Open($p, [System.IO.Compression.ZipArchiveMode]::Create)
+            foreach ($kvp in $tinyFiles.GetEnumerator()) {
+                $e = $zip.CreateEntry($kvp.Key, [System.IO.Compression.CompressionLevel]::Optimal)
+                $s = $e.Open()
+                $b = [System.Text.Encoding]::UTF8.GetBytes($kvp.Value)
+                $s.Write($b, 0, $b.Length)
+                $s.Close()
+            }
+            $zip.Dispose()
+
+            $originalBytes = [System.IO.File]::ReadAllBytes($p)
+            $results = @([PSCustomObject]@{ SheetName = '2603'; Result = [PSCustomObject]@{ DataEndRow = 1 } })
+            { Set-SubcategoryValidationXml -WorkbookPath $p -SyncResults $results } | Should -Not -Throw
+            # Workbook must not be overwritten -- the size guard fired and discarded the temp file
+            [System.IO.File]::ReadAllBytes($p) | Should -Be $originalBytes
+        }
     }
 }

--- a/Tests/Test-SubcategoryValid.Tests.ps1
+++ b/Tests/Test-SubcategoryValid.Tests.ps1
@@ -66,4 +66,11 @@ Describe 'Test-SubcategoryValid' {
                 Should -BeTrue
         }
     }
+
+    Context 'given an empty subcategory string' {
+        It 'returns false, clearing any preserved subcategory value' {
+            Test-SubcategoryValid -Category 'Food & Dining' -Subcategory '' -Categories $script:cats |
+                Should -BeFalse
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- **#74** `Get-Methods.Tests.ps1`: replace manual temp dirs with `$TestDrive`, add empty-array case, add default count assertion
- **#75** `ConvertFrom-ReceiptFileName.Tests.ps1`: rename `ParseOK=false` → `OK=false`, add `ParseError` assertions to all missing-account tests, add `Date` assertion to empty-fields test
- **#77** `Test-SubcategoryValid`, `Set-SubcategoryValidationXml`, `Lint.Tests.ps1`: empty subcategory test, size-guard path test (617-byte zip), settings-file existence guard

## Test plan
- [x] All 125 tests pass locally (up from 122)
- [x] Size guard test confirmed: tiny.xlsx reconstructed to 617 bytes, early-return fired without overwriting workbook
- [x] Pre-commit hooks passed (ASCII + lint)

closes #74
closes #75
closes #77