### PR TITLE
fix(setup): create launcher shortcuts in WORKBOOKS_ROOT instead of RECEIPTS_ROOT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.1] - 2026-03-21
+
+### Fixed
+- Launcher shortcuts are now created in `WORKBOOKS_ROOT` instead of `RECEIPTS_ROOT`.
+  For users with a separate workbooks location (ADR-006), shortcuts now appear alongside
+  the year workbooks where they are most useful. Single-location setups are unaffected
+  (`WORKBOOKS_ROOT` defaults to `RECEIPTS_ROOT` when not set).
+
+---
+
 ## [4.0.0] - 2026-03-21
 
 ### Changed (breaking)

--- a/Scripts/Initialize-SyncReceipts.ps1
+++ b/Scripts/Initialize-SyncReceipts.ps1
@@ -13,7 +13,7 @@
       5. Copies Accounts.template.xlsx to Config\Accounts.xlsx (skipped if present).
       6. Copies Categories.template.json to Config\Categories.json (skipped if present).
       7. Copies Methods.template.json to Config\Methods.json (skipped if present).
-      8. Creates Windows shortcut (.lnk) files in RECEIPTS_ROOT that point to the batch
+      8. Creates Windows shortcut (.lnk) files in WORKBOOKS_ROOT that point to the batch
          launchers in the script directory, with WorkingDirectory set so UNC-path shortcuts
          open without the "UNC paths are not supported" CMD error.
       9. Installs Pester and PSScriptAnalyzer (required by the pre-commit and pre-push hooks).
@@ -384,11 +384,11 @@ if (Test-Path $methodsJson) {
 }
 
 # ---------------------------------------------------------------------------
-# 5. Create shortcuts in RECEIPTS_ROOT
+# 5. Create shortcuts in WORKBOOKS_ROOT
 # ---------------------------------------------------------------------------
 
 Write-Host ""
-Write-Step "Creating shortcuts in $receiptsRoot..."
+Write-Step "Creating shortcuts in $workbooksRoot..."
 
 $shortcuts = @(
     @{
@@ -416,7 +416,7 @@ $shortcuts = @(
 $wsh = New-Object -ComObject WScript.Shell
 foreach ($s in $shortcuts) {
     try {
-        $lnkPath          = Join-Path $receiptsRoot $s.Name
+        $lnkPath          = Join-Path $workbooksRoot $s.Name
         $verb             = if (Test-Path $lnkPath) { "Updated" } else { "Created" }
         $shortcut         = $wsh.CreateShortcut($lnkPath)
         $shortcut.TargetPath       = $s.Target


### PR DESCRIPTION
## Summary
Shortcuts created by `Initialize-SyncReceipts.ps1` were always placed in `RECEIPTS_ROOT`. They now go to `WORKBOOKS_ROOT`, where the year workbooks live. Single-location setups are unaffected — `WORKBOOKS_ROOT` defaults to `RECEIPTS_ROOT` when not separately configured.

## Test plan
- [x] 125/125 Pester tests pass
- [x] ASCII and lint checks pass

Closes #113