### PR TITLE
fix(ci): auto-install PSScriptAnalyzer and catch container failures in pre-push hook

### DIFF
--- a/Scripts/hooks/Invoke-PrePushCheck.ps1
+++ b/Scripts/hooks/Invoke-PrePushCheck.ps1
@@ -5,7 +5,8 @@
 
 .DESCRIPTION
     Called by .git/hooks/pre-push via Scripts/Install-GitHooks.ps1.
-    Exits 0 if all tests pass; exits 1 if any test fails or Pester is missing.
+    Exits 0 if all tests pass; exits 1 if any test fails, any test file fails to
+    load, or a required module (Pester, PSScriptAnalyzer) cannot be found or installed.
 #>
 
 $pesterAvailable = Get-Module -ListAvailable Pester -ErrorAction SilentlyContinue |
@@ -15,6 +16,19 @@ if (-not $pesterAvailable) {
     Write-Host ("pre-push: Pester 5+ is not installed. " +
         "Run: Install-Module Pester -MinimumVersion 5.0 -Scope CurrentUser") -ForegroundColor Red
     exit 1
+}
+
+$analyzerAvailable = Get-Module -ListAvailable PSScriptAnalyzer -ErrorAction SilentlyContinue
+if (-not $analyzerAvailable) {
+    Write-Host "pre-push: PSScriptAnalyzer not installed -- installing..." -ForegroundColor Yellow
+    try {
+        Install-Module PSScriptAnalyzer -Scope CurrentUser -Force -ErrorAction Stop
+        Write-Host "pre-push: PSScriptAnalyzer installed." -ForegroundColor Green
+    } catch {
+        Write-Host ("pre-push: failed to install PSScriptAnalyzer: $_. " +
+            "Run: Install-Module PSScriptAnalyzer -Scope CurrentUser") -ForegroundColor Red
+        exit 1
+    }
 }
 
 Import-Module Pester -MinimumVersion 5.0 -Force
@@ -29,10 +43,20 @@ $cfg.Output.Verbosity = 'Detailed'
 $cfg.Run.PassThru     = $true
 $result = Invoke-Pester -Configuration $cfg
 
-if ($result.FailedCount -gt 0) {
+$failedContainers = @($result.Containers | Where-Object { $_.Result -eq 'Failed' })
+if ($result.FailedCount -gt 0 -or $failedContainers.Count -gt 0) {
     Write-Host ""
-    Write-Host ("pre-push: $($result.FailedCount) test(s) failed. " +
-        "Fix failures before pushing.") -ForegroundColor Red
+    if ($result.FailedCount -gt 0) {
+        Write-Host ("pre-push: $($result.FailedCount) test(s) failed. " +
+            "Fix failures before pushing.") -ForegroundColor Red
+    }
+    if ($failedContainers.Count -gt 0) {
+        Write-Host ("pre-push: $($failedContainers.Count) test file(s) failed to load. " +
+            "Fix discovery errors before pushing.") -ForegroundColor Red
+        foreach ($c in $failedContainers) {
+            Write-Host "  - $($c.Item.Path)" -ForegroundColor Red
+        }
+    }
     exit 1
 }
 


### PR DESCRIPTION
## Summary

- Auto-install PSScriptAnalyzer on first push if missing, rather than failing with a manual install prompt
- Catch Pester container/discovery failures (not just test failures) so a missing module can no longer cause lint to be silently skipped

## Test plan

- [ ] Verify the hook installs PSScriptAnalyzer automatically when absent
- [ ] Verify a container discovery failure now causes the hook to exit 1

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)