### PR TITLE
fix(ci): create GitHub Release directly in auto-release workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -84,3 +84,20 @@ jobs:
           git tag "${{ steps.version.outputs.tag }}"
           git push origin "${{ steps.version.outputs.tag }}"
           echo "Tagged and pushed ${{ steps.version.outputs.tag }}"
+
+      - name: Extract release notes
+        if: steps.check.outputs.skip == 'false'
+        id: notes
+        run: |
+          VERSION="${{ steps.version.outputs.new }}"
+          notes=$(awk "/^## \[$VERSION\]/{found=1; next} found && /^---$/{exit} found{print}" CHANGELOG.md)
+          echo "content<<EOF" >> $GITHUB_OUTPUT
+          echo "$notes"       >> $GITHUB_OUTPUT
+          echo "EOF"          >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        if: steps.check.outputs.skip == 'false'
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          body: ${{ steps.notes.outputs.content }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- `auto-release.yml` now creates the GitHub Release directly instead of relying on a tag push to trigger `release.yml`. The previous approach silently failed because GitHub Actions does not fire downstream workflows when `GITHUB_TOKEN` pushes a tag.
+
+---
+
 ## [4.0.3] - 2026-03-22
 
 ### Added


### PR DESCRIPTION
## Summary

Fixes the silent failure where `v4.0.3` was tagged but no GitHub Release was published. GitHub Actions does not trigger downstream workflows when `GITHUB_TOKEN` pushes a tag, so `release.yml` never fired.

Closes #126 (follow-up fix)

## Changes

- `.github/workflows/auto-release.yml` -- adds Extract release notes and Create GitHub Release steps directly, using the same `softprops/action-gh-release` action as `release.yml`
- `CHANGELOG.md` -- `[Unreleased]` entry documenting the fix

## Checklist

- [x] `Invoke-Pester Tests/ -Output Detailed` passes with no failures
- [x] PSScriptAnalyzer reports no Error or Warning violations on changed `.ps1` files
- [x] No non-ASCII characters in changed `.ps1` files
- [x] Commit messages follow Conventional Commits format
- [x] `CHANGELOG.md` updated (if user-facing change)
- [x] Documentation updated (README, CONTRIBUTING, or CLAUDE.md as applicable)