### PR TITLE
ci: add methods and adr to commit-lint known scope list

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -45,7 +45,7 @@ jobs:
           fi
 
           # Warn if scope is not in the known list (non-blocking)
-          KNOWN="ps1 logging categories accounts write-month convert-receipt xml tests readme claude.md ci config changelog contributing security"
+          KNOWN="ps1 logging categories accounts write-month convert-receipt xml tests readme claude.md ci config changelog contributing security methods adr"
           SCOPE=$(echo "$MSG" | grep -oP '(?<=\()[^)]+' || true)
           if [ -n "$SCOPE" ]; then
             if ! echo "$KNOWN" | grep -qw "$SCOPE"; then


### PR DESCRIPTION
## Summary
- Adds `methods` and `adr` to the `KNOWN` scope variable in `commit-lint.yml` (line 48)
- Eliminates spurious CI warnings when committing with `feat(methods):` or `docs(adr):` scopes

## Test plan
- [ ] Verify CI passes on this PR
- [ ] Confirm no warning appears for a commit message using `feat(methods):` or `docs(adr):`

Closes #124