### PR TITLE
chore(config): remove stale Release: Bump version VS Code task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,11 +5,6 @@
             "id": "releaseVersion",
             "type": "promptString",
             "description": "Release version tag (e.g. v2.1.0)"
-        },
-        {
-            "id": "bumpVersion",
-            "type": "promptString",
-            "description": "New version number -- no v prefix (e.g. 2.1.0)"
         }
     ],
     "tasks": [
@@ -184,23 +179,6 @@
                 "-NonInteractive",
                 "-Command",
                 "$cfg = @{}; Get-Content '${workspaceFolder}\\Config\\Config.ini' | Where-Object { $_ -notmatch '^\\s*#' -and $_ -match '=' } | ForEach-Object { $p = $_ -split '=',2; $cfg[$p[0].Trim()] = $p[1].Trim() }; & '${workspaceFolder}\\Scripts\\Sync-Receipts.ps1' -ReceiptsRoot $cfg['RECEIPTS_ROOT'] -KillExcel"
-            ],
-            "group": "build",
-            "presentation": {
-                "reveal": "always",
-                "panel": "shared",
-                "clear": true
-            },
-            "problemMatcher": []
-        },
-        {
-            "label": "Release: Bump version",
-            "type": "shell",
-            "command": "powershell",
-            "args": [
-                "-NoProfile",
-                "-Command",
-                "$v = '${input:bumpVersion}'; $f = '${workspaceFolder}\\Scripts\\Sync-Receipts.ps1'; $lines = Get-Content $f; $lines[0] = \"# Sync-Receipts.ps1  v$v\"; for ($i = 0; $i -lt $lines.Count; $i++) { if ($lines[$i] -match '^\\s+Version\\s*:') { $lines[$i] = $lines[$i] -replace '\\d+\\.\\d+\\.\\d+', $v; break } }; Set-Content $f $lines -Encoding ASCII; code $f"
             ],
             "group": "build",
             "presentation": {


### PR DESCRIPTION
## Summary
- Removes the `Release: Bump version` task from `.vscode/tasks.json`
- Removes the orphaned `bumpVersion` input definition
- The task patched `Scripts/Sync-Receipts.ps1` line 1 with a version string, contradicting the rule that version is tracked in git tags only and the script header carries no version number

## Test plan
- [ ] Verify `tasks.json` is valid JSON (done locally via `ConvertFrom-Json`)
- [ ] Confirm the `Release: Tag and push` task (which uses `releaseVersion`) still appears in VS Code task list
- [ ] Confirm `Release: Bump version` no longer appears

Closes #123