### PR TITLE
docs: add missing scripts to README, fix SECURITY versions, add .EXAMPLE

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Script files (e.g. C:\Scripts\Sync-Receipts\):
     Scripts\
         Initialize-SyncReceipts.ps1
         Sync-Receipts.ps1
+        New-AccountsTemplate.ps1     <- regenerates Config\Templates\Accounts.template.xlsx after schema changes
+        Install-GitHooks.ps1         <- copies Scripts\hooks\ into .git\hooks\
     Launchers\
         Run-SyncReceipts.bat
         Run-SyncMonthReceipts.bat

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ Only the latest release is actively maintained.
 
 | Version | Supported |
 |---------|-----------|
-| 1.0.x   | Yes       |
-| < 1.0   | No        |
+| 4.x     | Yes       |
+| < 4     | No        |
 
 ## Reporting a Vulnerability
 

--- a/Scripts/Initialize-SyncReceipts.ps1
+++ b/Scripts/Initialize-SyncReceipts.ps1
@@ -24,6 +24,11 @@
 
     The script is safe to re-run -- steps that are already complete are skipped.
 
+.EXAMPLE
+    PowerShell -NoProfile -ExecutionPolicy Bypass -File Scripts\Initialize-SyncReceipts.ps1
+
+    Runs the setup script from the repo root. Equivalent to running Setup.bat.
+
 .NOTES
     Requires: PowerShell 5.0+, Microsoft Excel (COM automation)
     Tested on: Windows 10/11


### PR DESCRIPTION
## Summary
- **README** (`#119`): adds `New-AccountsTemplate.ps1` and `Install-GitHooks.ps1` to the `Scripts\` folder structure diagram with inline descriptions
- **SECURITY.md** (`#120`): updates Supported Versions table from `1.0.x / < 1.0` to `4.x / < 4`, reflecting the current v4.0.4 release
- **Initialize-SyncReceipts.ps1** (`#122`): adds a `.EXAMPLE` block to the script-level comment-based help so `Get-Help -Examples` returns a usable invocation

## Test plan
- [ ] CI passes (lint checks `Initialize-SyncReceipts.ps1`)
- [ ] `Get-Help Scripts\Initialize-SyncReceipts.ps1 -Examples` returns the new example

Closes #119, closes #120, closes #122