### PR TITLE
test(tests): rename Context blocks to use BDD given/when language

### DIFF
--- a/Tests/ConvertFrom-ReceiptFileName.Tests.ps1
+++ b/Tests/ConvertFrom-ReceiptFileName.Tests.ps1
@@ -17,7 +17,7 @@ BeforeAll {
 
 Describe 'ConvertFrom-ReceiptFileName' {
 
-    Context 'valid filenames' {
+    Context 'given a filename with all fields present' {
 
         # Baseline
         It 'parses all fields: date, vendor, amount, method, account' {
@@ -124,7 +124,7 @@ Describe 'ConvertFrom-ReceiptFileName' {
         }
     }
 
-    Context 'invalid filenames' {
+    Context 'given a filename that cannot be parsed' {
 
         # Structural failures
         It 'returns OK=false for a non-receipt filename' {
@@ -216,7 +216,7 @@ Describe 'ConvertFrom-ReceiptFileName' {
         }
     }
 
-    Context 'no Method or Account' {
+    Context 'given a filename with Method and Account omitted' {
 
         It 'returns OK=true when Method and Account are omitted' {
             $r = ConvertFrom-ReceiptFileName -Stem '260301 Amazon -$10.00'
@@ -248,7 +248,7 @@ Describe 'ConvertFrom-ReceiptFileName' {
         }
     }
 
-    Context '-DateFormat variations' {
+    Context 'when a non-default -DateFormat is supplied' {
 
         It 'parses yyyyMMdd format' {
             $r = ConvertFrom-ReceiptFileName -Stem '20260316 Sunoco $5.27 Card 9080' -DateFormat 'yyyyMMdd'
@@ -296,7 +296,7 @@ Describe 'ConvertFrom-ReceiptFileName' {
         }
     }
 
-    Context '-Methods parameter' {
+    Context 'when a custom -Methods list is supplied' {
 
         It 'accepts a custom token when it is included in -Methods' {
             $r = ConvertFrom-ReceiptFileName -Stem '260301 Shop -$10.00 Crypto 1234' -Methods @('Card', 'Crypto')

--- a/Tests/Get-Methods.Tests.ps1
+++ b/Tests/Get-Methods.Tests.ps1
@@ -17,7 +17,7 @@ BeforeAll {
 
 Describe 'Get-Methods' {
 
-    Context 'reading from Methods.json' {
+    Context 'given a ConfigRoot directory' {
 
         It 'returns the token list from a valid JSON file' {
             $dir = Join-Path $TestDrive ([System.Guid]::NewGuid())

--- a/Tests/Set-SubcategoryValidationXml.Tests.ps1
+++ b/Tests/Set-SubcategoryValidationXml.Tests.ps1
@@ -137,7 +137,7 @@ BeforeAll {
 
 Describe 'Set-SubcategoryValidationXml' {
 
-    Context 'happy path -- single sheet' {
+    Context 'given a workbook with a single sheet and valid sync results' {
         BeforeAll {
             $script:xlsxPath = Join-Path $TestDrive 'happy.xlsx'
             New-MinimalXlsx -Path $script:xlsxPath -SheetName '2603'
@@ -200,7 +200,7 @@ Describe 'Set-SubcategoryValidationXml' {
         }
     }
 
-    Context 'edge cases' {
+    Context 'given sync results that do not match workbook content' {
 
         It 'skips a sheet whose DataEndRow is less than 2' {
             $p = Join-Path $TestDrive 'skip-nodata.xlsx'

--- a/Tests/Write-SyncLog.Tests.ps1
+++ b/Tests/Write-SyncLog.Tests.ps1
@@ -17,7 +17,7 @@ BeforeAll {
 
 Describe 'Write-SyncLog' {
 
-    Context 'output format' {
+    Context 'given any log message' {
 
         It 'includes a [HH:mm:ss] timestamp' {
             Mock Write-Host {}
@@ -62,7 +62,7 @@ Describe 'Write-SyncLog' {
         }
     }
 
-    Context 'tag routing and color' {
+    Context 'when a specific tag is supplied' {
 
         It 'INFO writes to Write-Host and not Write-Verbose' {
             Mock Write-Host {}
@@ -105,7 +105,7 @@ Describe 'Write-SyncLog' {
         }
     }
 
-    Context 'default tag' {
+    Context 'when no tag is specified' {
 
         It 'defaults to INFO when no tag is specified' {
             Mock Write-Host {}
@@ -114,7 +114,7 @@ Describe 'Write-SyncLog' {
         }
     }
 
-    Context 'parameter validation' {
+    Context 'given an unrecognised tag value' {
 
         It 'throws for an unrecognised tag' {
             { Write-SyncLog 'msg' -Tag 'UNKNOWN' } | Should -Throw


### PR DESCRIPTION
## Summary
- Renames 12 non-conforming `Context` blocks across four test files to use `given`/`when`/`with` language per the BDD naming convention in CLAUDE.md
- Files affected: `ConvertFrom-ReceiptFileName.Tests.ps1` (5), `Get-Methods.Tests.ps1` (1), `Write-SyncLog.Tests.ps1` (4), `Set-SubcategoryValidationXml.Tests.ps1` (2)
- No test logic changes — rename-only

## Test plan
- [ ] CI passes — all 154 tests green
- [ ] `Invoke-Pester -Output Detailed` output reads as a behavioural specification

Closes #121